### PR TITLE
Fix evolve ends glitch.  Add restart capabilities.

### DIFF
--- a/tcl/stringmethod.tcl
+++ b/tcl/stringmethod.tcl
@@ -29,8 +29,8 @@ puts stdout "CFACV/SM) replica id $replica_id"
 # check for restart
 # $restart_root is set by the restart file
 # sourced in jobN.conf (N>0) 
-if {[info exists restart_root]} {
-  source $restart_root.tcl
+if {[info exists restart_file]} {
+  source $restart_file
 } else {
   set i_job 0
   set i_run 0


### PR DESCRIPTION
Issue with evolve ends fixed.  Restart capabilities added.  Restart restraint files are written to same folder as previous restart files under name ${init_restart_file_name}.restart${run}.  Restart file must be given in stringmethod.conf as "set restart_file "source_restart_file.tcl"".